### PR TITLE
Fix model path in evaluation.py

### DIFF
--- a/pig/evaluation.py
+++ b/pig/evaluation.py
@@ -39,7 +39,8 @@ def load_best_model(dirname, higher_better=True):
        info.append(cp['callbacks'][pl.callbacks.model_checkpoint.ModelCheckpoint])
     best = sorted(info, key=lambda x: x['best_model_score'], reverse=higher_better)[0]
     logging.info(f"Best {best['monitor']}: {best['best_model_score']} at {best['best_model_path']}")
-    net = PeppaPig.load_from_checkpoint(best['best_model_path'])
+    local_model_path = best['best_model_path'].split("/peppa/")[1]
+    net = PeppaPig.load_from_checkpoint(local_model_path)
     return net, best['best_model_path']
 
 def score(model, gpus):


### PR DESCRIPTION
The stored model paths are currently absolute paths, we need to cut the first part in order to be able to evaluate checkpoints on a different machine